### PR TITLE
Poke detail option menus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1785,6 +1785,151 @@
         }
       }
     },
+    "@material-ui/core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.3.tgz",
+      "integrity": "sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.11.3",
+        "@material-ui/system": "^4.11.3",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.11.2",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.4",
+        "hoist-non-react-statics": "^3.3.2",
+        "popper.js": "1.16.1-lts",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0",
+        "react-transition-group": "^4.4.0"
+      },
+      "dependencies": {
+        "@material-ui/styles": {
+          "version": "4.11.3",
+          "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.3.tgz",
+          "integrity": "sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@emotion/hash": "^0.8.0",
+            "@material-ui/types": "^5.1.0",
+            "@material-ui/utils": "^4.11.2",
+            "clsx": "^1.0.4",
+            "csstype": "^2.5.2",
+            "hoist-non-react-statics": "^3.3.2",
+            "jss": "^10.5.1",
+            "jss-plugin-camel-case": "^10.5.1",
+            "jss-plugin-default-unit": "^10.5.1",
+            "jss-plugin-global": "^10.5.1",
+            "jss-plugin-nested": "^10.5.1",
+            "jss-plugin-props-sort": "^10.5.1",
+            "jss-plugin-rule-value-function": "^10.5.1",
+            "jss-plugin-vendor-prefixer": "^10.5.1",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@material-ui/utils": {
+          "version": "4.11.2",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+          "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0 || ^17.0.0"
+          }
+        },
+        "jss": {
+          "version": "10.5.1",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.1.tgz",
+          "integrity": "sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "csstype": "^3.0.2",
+            "indefinite-observable": "^2.0.1",
+            "is-in-browser": "^1.1.3",
+            "tiny-warning": "^1.0.2"
+          },
+          "dependencies": {
+            "csstype": {
+              "version": "3.0.6",
+              "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+              "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+            }
+          }
+        },
+        "jss-plugin-camel-case": {
+          "version": "10.5.1",
+          "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.5.1.tgz",
+          "integrity": "sha512-9+oymA7wPtswm+zxVti1qiowC5q7bRdCJNORtns2JUj/QHp2QPXYwSNRD8+D2Cy3/CEMtdJzlNnt5aXmpS6NAg==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "hyphenate-style-name": "^1.0.3",
+            "jss": "10.5.1"
+          }
+        },
+        "jss-plugin-default-unit": {
+          "version": "10.5.1",
+          "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.5.1.tgz",
+          "integrity": "sha512-D48hJBc9Tj3PusvlillHW8Fz0y/QqA7MNmTYDQaSB/7mTrCZjt7AVRROExoOHEtd2qIYKOYJW3Jc2agnvsXRlQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "jss": "10.5.1"
+          }
+        },
+        "jss-plugin-global": {
+          "version": "10.5.1",
+          "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.5.1.tgz",
+          "integrity": "sha512-jX4XpNgoaB8yPWw/gA1aPXJEoX0LNpvsROPvxlnYe+SE0JOhuvF7mA6dCkgpXBxfTWKJsno7cDSCgzHTocRjCQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "jss": "10.5.1"
+          }
+        },
+        "jss-plugin-nested": {
+          "version": "10.5.1",
+          "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.5.1.tgz",
+          "integrity": "sha512-xXkWKOCljuwHNjSYcXrCxBnjd8eJp90KVFW1rlhvKKRXnEKVD6vdKXYezk2a89uKAHckSvBvBoDGsfZrldWqqQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "jss": "10.5.1",
+            "tiny-warning": "^1.0.2"
+          }
+        },
+        "jss-plugin-props-sort": {
+          "version": "10.5.1",
+          "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.5.1.tgz",
+          "integrity": "sha512-t+2vcevNmMg4U/jAuxlfjKt46D/jHzCPEjsjLRj/J56CvP7Iy03scsUP58Iw8mVnaV36xAUZH2CmAmAdo8994g==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "jss": "10.5.1"
+          }
+        },
+        "jss-plugin-rule-value-function": {
+          "version": "10.5.1",
+          "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.5.1.tgz",
+          "integrity": "sha512-3gjrSxsy4ka/lGQsTDY8oYYtkt2esBvQiceGBB4PykXxHoGRz14tbCK31Zc6DHEnIeqsjMUGbq+wEly5UViStQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "jss": "10.5.1",
+            "tiny-warning": "^1.0.2"
+          }
+        },
+        "jss-plugin-vendor-prefixer": {
+          "version": "10.5.1",
+          "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.5.1.tgz",
+          "integrity": "sha512-cLkH6RaPZWHa1TqSfd2vszNNgxT1W0omlSjAd6hCFHp3KIocSrW21gaHjlMU26JpTHwkc+tJTCQOmE/O1A4FKQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "css-vendor": "^2.0.8",
+            "jss": "10.5.1"
+          }
+        },
+        "popper.js": {
+          "version": "1.16.1-lts",
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+          "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
+        }
+      }
+    },
     "@material-ui/styles": {
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1808,6 +1808,29 @@
         "prop-types": "^15.7.2"
       }
     },
+    "@material-ui/system": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.3.tgz",
+      "integrity": "sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "csstype": "^2.5.2",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@material-ui/utils": {
+          "version": "4.11.2",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+          "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0 || ^17.0.0"
+          }
+        }
+      }
+    },
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
@@ -2362,10 +2385,39 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
       "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ=="
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
     "@types/q": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
+    },
+    "@types/react": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==",
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+        }
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==",
+      "requires": {
+        "@types/react": "*"
+      }
     },
     "@types/resolve": {
       "version": "0.0.8",
@@ -5098,6 +5150,22 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+        }
       }
     },
     "dom-serializer": {
@@ -10017,6 +10085,25 @@
         "object-visit": "^1.0.0"
       }
     },
+    "material-ui-core": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/material-ui-core/-/material-ui-core-5.0.1.tgz",
+      "integrity": "sha512-oq95i9ZHWQlbE+QJqtUiFXCni2msyyQgSDC9SlVPOg6r1mnr8Cn44Q+f238uD4B2entE3s/JxyAvNUyYMdhHVg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.9.0",
+        "@material-ui/system": "^4.9.3",
+        "@material-ui/types": "^5.0.0",
+        "@material-ui/utils": "^4.7.1",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "popper.js": "^1.14.1",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0",
+        "react-transition-group": "^4.3.0"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -11153,6 +11240,11 @@
       "requires": {
         "ts-pnp": "^1.1.6"
       }
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "portfinder": {
       "version": "1.0.28",
@@ -12684,6 +12776,17 @@
         "webpack-dev-server": "3.11.0",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "5.1.4"
+      }
+    },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^11.1.2",
     "@testing-library/user-event": "^12.2.2",
     "axios": "^0.21.0",
+    "material-ui-core": "^5.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@material-ui/core": "^4.11.3",
     "@material-ui/styles": "^4.11.1",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.1.2",

--- a/src/components/PokemonDetail/PokemonDetail.js
+++ b/src/components/PokemonDetail/PokemonDetail.js
@@ -6,6 +6,7 @@ import OptionMenu from '../PokemonDetailMenu/OverviewOption';
 import PokemonDetailMainScreen from '../PokemonDetailMainScreen/OverviewOptionContent';
 import PokemonDetailStats from '../PokemonDetail/PokemonDetailStats';
 import PokedexBase from '../PokedexBase';
+import OptionsContainer from '../PokemonDetailMenu/OptionsContainer'
 
 /* 
 This component is responsible for the Pokemon Detail page, it calls the Pokedex Base and the Pokemon detail related components
@@ -18,7 +19,7 @@ function PokemonDetail(props) {
     const[pokemon, setPokemon] = useState([]);
     const[loading, setLoading] = useState(true);
     const mainScreen =  <PokemonDetailMainScreen pokemon={pokemon}/>
-    const optionMenu =  <OptionMenu/>
+    const optionMenu =  <OptionsContainer/>
     const statScreen = <PokemonDetailStats pokemon={pokemon}/>
 
     const useStyle = makeStyles({

--- a/src/components/PokemonDetail/PokemonDetail.js
+++ b/src/components/PokemonDetail/PokemonDetail.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { useEffect, useState, useContext } from 'react';
 import { useParams } from 'react-router-dom';
 import { makeStyles } from '@material-ui/styles';
-import OptionMenu from '../PokemonDetailMenu/OverviewOption';
+import OverviewOption from '../PokemonDetailMenu/OverviewOption';
 import PokemonDetailMainScreen from '../PokemonDetailMainScreen/OverviewOptionContent';
 import PokemonDetailStats from '../PokemonDetail/PokemonDetailStats';
 import PokedexBase from '../PokedexBase';
@@ -18,8 +18,9 @@ function PokemonDetail(props) {
     let {id} = useParams();
     const[pokemon, setPokemon] = useState([]);
     const[loading, setLoading] = useState(true);
+    const overviewOption = <OverviewOption />
     const mainScreen =  <PokemonDetailMainScreen pokemon={pokemon}/>
-    const optionMenu =  <OptionsContainer/>
+    const optionMenu =  <OptionsContainer firstOption={overviewOption}/>
     const statScreen = <PokemonDetailStats pokemon={pokemon}/>
 
     const useStyle = makeStyles({

--- a/src/components/PokemonDetailMenu/OptionsContainer.js
+++ b/src/components/PokemonDetailMenu/OptionsContainer.js
@@ -1,15 +1,22 @@
 import React from 'react';
-import { ThemeProvider } from '@material-ui/styles';
-import { makeStyles } from '@material-ui/styles';
+import { ThemeProvider, makeStyles } from '@material-ui/core/styles';
 
 function OptionsContainer(props) {
 
     const style = useStyle();
+    //const firstOption = props.firstOption; 
+    const secondOption = props.secondOption;
+    const thirdOption = props.thirdOption;
+    const fourthOption = props.fourthOption;
 
     return (
         <div className={style.containerStyle}>
-
-            
+            <ThemeProvider theme={optionsTheme}>
+                {props.firstOption}
+                {props.secondOption}
+                {props.thirdOption}
+                {props.fourthOption}
+            </ThemeProvider>
         </div>
     )
 }
@@ -18,8 +25,12 @@ const optionsTheme = {
     sharedStyle: {
         paddingLeft: '20px',
         display: 'table-cell',
+        height: '50px',
+        width: 'inherit',
+        border: '2px solid red'
+
     },
-    overviewStyle: {
+    firstOptionStyle: {
         marginTop: '15px',
     }
 }

--- a/src/components/PokemonDetailMenu/OptionsContainer.js
+++ b/src/components/PokemonDetailMenu/OptionsContainer.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ThemeProvider } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
+
+function OptionsContainer(props) {
+
+    const style = useStyle();
+
+    return (
+        <div className={style.containerStyle}>
+
+            
+        </div>
+    )
+}
+
+const optionsTheme = {
+    sharedStyle: {
+        paddingLeft: '20px',
+        display: 'table-cell',
+    },
+    overviewStyle: {
+        marginTop: '15px',
+    }
+}
+
+const useStyle = makeStyles({
+    containerStyle: {
+        display: 'table-cell',
+        border: '2px solid yellow'
+    }
+})
+
+export default OptionsContainer

--- a/src/components/PokemonDetailMenu/OptionsContainer.js
+++ b/src/components/PokemonDetailMenu/OptionsContainer.js
@@ -26,7 +26,7 @@ const optionsTheme = {
         paddingLeft: '20px',
         display: 'table-cell',
         height: '50px',
-        width: 'inherit',
+        width: '300px',
         border: '2px solid red'
 
     },

--- a/src/components/PokemonDetailMenu/OptionsContainer.js
+++ b/src/components/PokemonDetailMenu/OptionsContainer.js
@@ -23,17 +23,21 @@ function OptionsContainer(props) {
 
 const optionsTheme = {
     sharedStyle: {
-        paddingLeft: '20px',
+        paddingLeft: '16px',
         display: 'flex',
         height: '35px',
-        width: '290px',
+        width: '293px',
         border: '2px solid red',
         margin: 'auto',
-        alignItems: 'center'
+        alignItems: 'center',
+        borderRadius: '5px'
 
     },
     firstOptionStyle: {
         marginTop: '7px',
+        "&:hover":{
+            backgroundColor: '#ff000082'
+        }
     }
 }
 

--- a/src/components/PokemonDetailMenu/OptionsContainer.js
+++ b/src/components/PokemonDetailMenu/OptionsContainer.js
@@ -24,14 +24,16 @@ function OptionsContainer(props) {
 const optionsTheme = {
     sharedStyle: {
         paddingLeft: '20px',
-        display: 'table-cell',
-        height: '50px',
-        width: '300px',
-        border: '2px solid red'
+        display: 'flex',
+        height: '35px',
+        width: '290px',
+        border: '2px solid red',
+        margin: 'auto',
+        alignItems: 'center'
 
     },
     firstOptionStyle: {
-        marginTop: '15px',
+        marginTop: '7px',
     }
 }
 

--- a/src/components/PokemonDetailMenu/OverviewOption.js
+++ b/src/components/PokemonDetailMenu/OverviewOption.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
+
 /* 
 This componant represents the Pokemon Detail page Overview Option, not finished yet, 
 TODO - should be clickable, on click: shows the Overview Option Content on the Main screen.
@@ -7,21 +8,12 @@ TODO - should be clickable, on click: shows the Overview Option Content on the M
 function OverviewOption() {
 
 
-    const useStyle = makeStyles({
-        textContainer: {
-            marginTop: '15px',
-            paddingLeft: '20px',
-            display: 'table-cell',
-        },
-
-
-    })
-
-
+    const overStyle = useTheme();
+    const useStyle = makeStyles(overStyle);
     const style = useStyle();
-
+    
     return (
-        <div className={style.textContainer}>
+        <div className={`${style.sharedStyle} ${style.firstOptionStyle}`}>
             <h3 >Overview</h3>
         </div>
     )


### PR DESCRIPTION
Created the Pokemon Detail Options Screen container, which consumes the Option components as props and display them in the Option Menu screen in the Pokemon Detail view, currently it's working with four props, so you can define four option at max.
It may be extended in the future.
It also controlls now the style of the Option components by using the MUI ThemeProvider to escape style code duplication in the Option components. 