### PR TITLE
Add PokemonDetail EvolutionOption Content component to dev

### DIFF
--- a/src/components/PokemonDetail/PokemonDetail.js
+++ b/src/components/PokemonDetail/PokemonDetail.js
@@ -3,10 +3,11 @@ import { useEffect, useState, useContext } from 'react';
 import { useParams } from 'react-router-dom';
 import { makeStyles } from '@material-ui/styles';
 import OverviewOption from '../PokemonDetailMenu/OverviewOption';
+import OptionsContainer from '../PokemonDetailMenu/OptionsContainer';
+import EvolutionOption from '../PokemonDetailMenu/EvolutionOptionMenu';
 import PokemonDetailMainScreen from '../PokemonDetailMainScreen/OverviewOptionContent';
 import PokemonDetailStats from '../PokemonDetail/PokemonDetailStats';
 import PokedexBase from '../PokedexBase';
-import OptionsContainer from '../PokemonDetailMenu/OptionsContainer'
 
 /* 
 This component is responsible for the Pokemon Detail page, it calls the Pokedex Base and the Pokemon detail related components
@@ -18,9 +19,12 @@ function PokemonDetail(props) {
     let {id} = useParams();
     const[pokemon, setPokemon] = useState([]);
     const[loading, setLoading] = useState(true);
+
     const overviewOption = <OverviewOption />
+    const evolutionOption = <EvolutionOption />
+
     const mainScreen =  <PokemonDetailMainScreen pokemon={pokemon}/>
-    const optionMenu =  <OptionsContainer firstOption={overviewOption}/>
+    const optionMenu =  <OptionsContainer firstOption={overviewOption} secondOption={evolutionOption}/>
     const statScreen = <PokemonDetailStats pokemon={pokemon}/>
 
     const useStyle = makeStyles({

--- a/src/components/PokemonDetailMainScreen/EvolutionOptionContent.js
+++ b/src/components/PokemonDetailMainScreen/EvolutionOptionContent.js
@@ -1,0 +1,27 @@
+import React, {useEffect, useState} from 'react';
+import {makeStyle} from '@material-ui/core/styles';
+import axios from 'axios';
+
+function EvolutionOptionContent(props) {
+
+    const[evolutionChain, setEvolutionChain] = useState();
+    const style = useStyle();
+
+    useEffect(() => {
+        axios(`https://pokeapi.co/api/v2/evolution-chain/${props.pokemonId}`)
+            .then(res => setEvolutionChain(res.data))
+    }, [])
+
+
+    return (
+        <div className={style.containerStyle}>
+            <h2>{evolutionChain}</h2>
+        </div>
+    )
+}
+
+const useStyle = makeStyle({
+    containerStyle: 'table-cell'
+})
+
+export default EvolutionOptionContent

--- a/src/components/PokemonDetailMenu/EvolutionOptionMenu.js
+++ b/src/components/PokemonDetailMenu/EvolutionOptionMenu.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { makeStyles, useTheme } from '@material-ui/core/styles';
+
+
+function EvolutionOptionMenu() {
+
+    const evolutionStyle = useTheme();
+    const useStyle = makeStyles(evolutionStyle)
+    const style = useStyle();
+    return (
+        <div className={`${style.sharedStyle} ${style.secondOptionStyle}`}>
+            <h3>Evolution</h3>
+        </div>
+    )
+}
+
+export default EvolutionOptionMenu


### PR DESCRIPTION
Created the base of the PokemonDetail EvolutionOption Content component, merging to development to be able to use in Pokemon Detail branch, to refactor the Pokemon Detail component to be able to handle the switch between the Content screens.