### PR TITLE
Added useState with screens object 

### DIFF
--- a/src/components/PokemonDetail/PokemonDetail.js
+++ b/src/components/PokemonDetail/PokemonDetail.js
@@ -17,24 +17,25 @@ Route: http://localhost:3000/pokemonId
 */
 function PokemonDetail(props) {
 
+    const activeScreens = {
+        mainScreen: null,
+        statScreen: null
+    }
     let {id} = useParams();
     const[pokemon, setPokemon] = useState([]);
     const[loading, setLoading] = useState(true);
+    const[screens, setScreens] = useState(activeScreens)
     
     
     
     /* const[mainScreen, setMainScreen] = useState();
     const[statScreen, setStatScreen] = useState(); */
     
-    const activeScreens = {
-        mainScreen: null,
-        statScreen: null
-    }
+    
     
     const style = useStyle();
     
-    const setMainScreen = (component) => activeScreens.mainScreen = component;
-    const setStatScreen = (component) => activeScreens.statScreen = component;
+  
     
     useEffect(() => {
         axios.get(`https://pokeapi.co/api/v2/pokemon/${id}`)
@@ -46,34 +47,33 @@ function PokemonDetail(props) {
     }, [])
     
     const handleOverviewOptionClick = () => {
-        setMainScreen(overviewOptionContent)
-        setStatScreen(overviewOptionStatScreen)
+        
+        setScreens(overviewOptionScreens)
     }
     
     const handleEvolutionOptionClick = () => {
-        setMainScreen(evolutionOptionContent)
-        setStatScreen(null)
+        setScreens(evolutionOptionScreens)
+
     }
     
-    const handleOptionClicks = {
-        firstOption: handleOverviewOptionClick,
-        secondOption: handleEvolutionOptionClick
-    }
-    const overviewOption = <OverviewOption handleClick={handleOptionClicks.firstOption}/>
-    const evolutionOption = <EvolutionOption handleClick={handleOptionClicks.secondOption}/>
+    const overviewOption = <OverviewOption handleClick={handleOverviewOptionClick}/>
+    const evolutionOption = <EvolutionOption handleClick={handleEvolutionOptionClick}/>
     
     const overviewOptionContent =  <OverviewOptionContent pokemon={pokemon} loading={loading}/>
     const evolutionOptionContent = <EvolutionOptionContent />
     
     const overviewOptionStatScreen = <PokemonDetailStats pokemon={pokemon} loading={loading}/>
     const optionMenu =  <OptionsContainer firstOption={overviewOption} secondOption={evolutionOption}/>
+
+    const overviewOptionScreens = {mainScreen: overviewOptionContent, statScreen: overviewOptionStatScreen}
+    const evolutionOptionScreens = {mainScreen: evolutionOptionContent, statScreen: null}
     
     return (
         
         !loading ?
         <div  style={style.poContainerStyle}>  
-        <PokedexBase toggleTheme={props.toggleTheme} mainScreen={activeScreens.mainScreen} 
-        optionMenu={optionMenu} statScreen={activeScreens.statScreen}/>
+        <PokedexBase toggleTheme={props.toggleTheme} mainScreen={screens.mainScreen} 
+        optionMenu={optionMenu} statScreen={screens.statScreen}/>
         </div>
         : <div><h2>Loading..</h2></div>
         )

--- a/src/components/PokemonDetail/PokemonDetail.js
+++ b/src/components/PokemonDetail/PokemonDetail.js
@@ -5,7 +5,8 @@ import { makeStyles } from '@material-ui/styles';
 import OverviewOption from '../PokemonDetailMenu/OverviewOption';
 import OptionsContainer from '../PokemonDetailMenu/OptionsContainer';
 import EvolutionOption from '../PokemonDetailMenu/EvolutionOptionMenu';
-import PokemonDetailMainScreen from '../PokemonDetailMainScreen/OverviewOptionContent';
+import EvolutionOptionContent from '../PokemonDetailMainScreen/EvolutionOptionContent'
+import OverviewOptionContent from '../PokemonDetailMainScreen/OverviewOptionContent';
 import PokemonDetailStats from '../PokemonDetail/PokemonDetailStats';
 import PokedexBase from '../PokedexBase';
 
@@ -19,14 +20,65 @@ function PokemonDetail(props) {
     let {id} = useParams();
     const[pokemon, setPokemon] = useState([]);
     const[loading, setLoading] = useState(true);
-
-    const overviewOption = <OverviewOption />
-    const evolutionOption = <EvolutionOption />
-
-    const mainScreen =  <PokemonDetailMainScreen pokemon={pokemon}/>
+    
+    
+    
+    /* const[mainScreen, setMainScreen] = useState();
+    const[statScreen, setStatScreen] = useState(); */
+    
+    const activeScreens = {
+        mainScreen: null,
+        statScreen: null
+    }
+    
+    const style = useStyle();
+    
+    const setMainScreen = (component) => activeScreens.mainScreen = component;
+    const setStatScreen = (component) => activeScreens.statScreen = component;
+    
+    useEffect(() => {
+        axios.get(`https://pokeapi.co/api/v2/pokemon/${id}`)
+        .then(res => {
+            console.log(res.data) 
+            setPokemon(res.data)
+            setLoading(false)
+        })
+    }, [])
+    
+    const handleOverviewOptionClick = () => {
+        setMainScreen(overviewOptionContent)
+        setStatScreen(overviewOptionStatScreen)
+    }
+    
+    const handleEvolutionOptionClick = () => {
+        setMainScreen(evolutionOptionContent)
+        setStatScreen(null)
+    }
+    
+    const handleOptionClicks = {
+        firstOption: handleOverviewOptionClick,
+        secondOption: handleEvolutionOptionClick
+    }
+    const overviewOption = <OverviewOption handleClick={handleOptionClicks.firstOption}/>
+    const evolutionOption = <EvolutionOption handleClick={handleOptionClicks.secondOption}/>
+    
+    const overviewOptionContent =  <OverviewOptionContent pokemon={pokemon} loading={loading}/>
+    const evolutionOptionContent = <EvolutionOptionContent />
+    
+    const overviewOptionStatScreen = <PokemonDetailStats pokemon={pokemon} loading={loading}/>
     const optionMenu =  <OptionsContainer firstOption={overviewOption} secondOption={evolutionOption}/>
-    const statScreen = <PokemonDetailStats pokemon={pokemon}/>
-
+    
+    return (
+        
+        !loading ?
+        <div  style={style.poContainerStyle}>  
+        <PokedexBase toggleTheme={props.toggleTheme} mainScreen={activeScreens.mainScreen} 
+        optionMenu={optionMenu} statScreen={activeScreens.statScreen}/>
+        </div>
+        : <div><h2>Loading..</h2></div>
+        )
+    }
+    
     const useStyle = makeStyles({
 
         pokemonContainer: {
@@ -34,28 +86,5 @@ function PokemonDetail(props) {
         },
 
     })
-
-    useEffect(() => {
-        axios.get(`https://pokeapi.co/api/v2/pokemon/${id}`)
-        .then(res => {
-            console.log(res.data) 
-            setPokemon(res.data)
-            setLoading(false)})
-    }, [])
-    
-    const style = useStyle();
-    
-
-    return (
-        
-        !loading ?
-        <div  style={style.poContainerStyle}>  
-            <PokedexBase toggleTheme={props.toggleTheme} mainScreen={mainScreen} 
-            optionMenu={optionMenu} statScreen={statScreen}/>
-        </div>
-        : <div><h2>Loading..</h2></div>
-    )
-}
-
 
 export default PokemonDetail

--- a/src/components/PokemonDetail/PokemonDetailStats.js
+++ b/src/components/PokemonDetail/PokemonDetailStats.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import { makeStyles } from '@material-ui/styles';
 
 
@@ -9,6 +9,8 @@ Props: pokemon - The pokemon object to get the actual pokemon attributes
 function PokemonDetailStats(props) {
 
     const pokemon = props.pokemon;
+    const[loading, setLoading] = useState(props.loading)
+    console.log(pokemon)
 
     const useStlye = makeStyles({
         statContainer: {
@@ -29,6 +31,7 @@ function PokemonDetailStats(props) {
     const style = useStlye();
 
     return (
+        !loading ?
         <div className={style.statContainer}>
             <div className={style.attribute}>
                 <h4>Hp: </h4>
@@ -51,6 +54,7 @@ function PokemonDetailStats(props) {
                 })}</div>
             </div>
         </div>
+        : <h3>Loading..</h3>
     )
 }
 

--- a/src/components/PokemonDetailMainScreen/EvolutionOptionContent.js
+++ b/src/components/PokemonDetailMainScreen/EvolutionOptionContent.js
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {makeStyle} from '@material-ui/core/styles';
+import {makeStyles} from '@material-ui/core/styles';
 import axios from 'axios';
 
 function EvolutionOptionContent(props) {
@@ -20,8 +20,8 @@ function EvolutionOptionContent(props) {
     )
 }
 
-const useStyle = makeStyle({
-    containerStyle: 'table-cell'
+const useStyle = makeStyles({
+    containerStyle: {display: 'table-cell'}
 })
 
 export default EvolutionOptionContent

--- a/src/components/PokemonDetailMainScreen/OverviewOptionContent.js
+++ b/src/components/PokemonDetailMainScreen/OverviewOptionContent.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useContext} from 'react';
+import React, {useState, useContext} from 'react';
 import { makeStyles } from '@material-ui/styles';
 import MediaContent from '../PokemonDetailMainScreen/MediaContent';
 import ThemeContext from '../ThemeContext';
@@ -11,6 +11,8 @@ function OverviewOptionContent(props) {
     const capitalize = (text) => text.charAt(0).toUpperCase()+text.slice(1);
     const isDefault = useContext(ThemeContext);
     const pokemon = props.pokemon;
+    const[loading, setLoading] = useState(props.loading);
+    console.log(pokemon);
 
     const useStyle = makeStyles({
 
@@ -96,6 +98,7 @@ function OverviewOptionContent(props) {
     const style = useStyle();
     
     return (
+        !loading ?
         <div>
             <div className={style.nameContent}>
                 <div className={style.nameContainer}>
@@ -129,6 +132,7 @@ function OverviewOptionContent(props) {
                 </div>
             </div>
         </div>
+        : <h3>Loading..</h3>
     )
 }
 

--- a/src/components/PokemonDetailMenu/EvolutionOptionMenu.js
+++ b/src/components/PokemonDetailMenu/EvolutionOptionMenu.js
@@ -2,13 +2,13 @@ import React from 'react'
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 
 
-function EvolutionOptionMenu() {
+function EvolutionOptionMenu(props) {
 
     const evolutionStyle = useTheme();
     const useStyle = makeStyles(evolutionStyle)
     const style = useStyle();
     return (
-        <div className={`${style.sharedStyle} ${style.secondOptionStyle}`}>
+        <div className={`${style.sharedStyle} ${style.secondOptionStyle}`} onClick={props.handleClick}>
             <h3>Evolution</h3>
         </div>
     )

--- a/src/components/PokemonDetailMenu/OverviewOption.js
+++ b/src/components/PokemonDetailMenu/OverviewOption.js
@@ -5,7 +5,7 @@ import { makeStyles, useTheme } from '@material-ui/core/styles';
 This componant represents the Pokemon Detail page Overview Option, not finished yet, 
 TODO - should be clickable, on click: shows the Overview Option Content on the Main screen.
 */
-function OverviewOption() {
+function OverviewOption(props) {
 
 
     const overStyle = useTheme();
@@ -13,7 +13,7 @@ function OverviewOption() {
     const style = useStyle();
     
     return (
-        <div className={`${style.sharedStyle} ${style.firstOptionStyle}`}>
+        <div className={`${style.sharedStyle} ${style.firstOptionStyle}`} onClick={props.handleClick}>
             <h3 >Overview</h3>
         </div>
     )


### PR DESCRIPTION
Added useState with screen objects, to be able to switche between the options (currently evolution and overview).
There is a screens state which contains the currently active mainScreen and statScreen of the PokemonDetail view.